### PR TITLE
changed generic Bundle-SymbolicName 'protege' to avoid clashes with other plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
 					<instructions>
 						<!--<Bundle-Activator>org.protege.editor.owl.ProtegeOWL</Bundle-Activator>-->
 						<Bundle-ClassPath>.</Bundle-ClassPath>
-						<Bundle-SymbolicName>${project.artifactId};singleton:=true</Bundle-SymbolicName>
+						<Bundle-SymbolicName>${project.groupId}.${project.artifactId};singleton:=true</Bundle-SymbolicName>
 						<Bundle-Vendor>DL-Learner Project</Bundle-Vendor>
 						<Import-Package>
 							javax.swing,


### PR DESCRIPTION
I replaced the Bundle-SymbolicName identifier "protege" with "org.dllearner.protege". Otherwise, this plugin would clash with any other plugins using the same generic name "protege" (only one of them will load). This happened for me with the [VOWL](https://github.com/VisualDataWeb/ProtegeVOWL) plugin.